### PR TITLE
feat: support deleting keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+store.json

--- a/index.html
+++ b/index.html
@@ -230,6 +230,21 @@
       if(!res.ok) throw new Error(out.error || `Save failed (${res.status})`);
       return out;
     }
+    async function apiDelete(key){
+      showError('');
+      const anon = getAnon();
+      if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
+      const res = await fetch(`${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`, {
+        method:'DELETE',
+        headers:{
+          'Authorization': `Bearer ${anon}`,
+          'x-cms-secret': WRITE_SECRET
+        }
+      });
+      const out = await res.json().catch(()=>({}));
+      if(!res.ok) throw new Error(out.error || `Delete failed (${res.status})`);
+      return out;
+    }
 
     // ---- Hours UI ----
     function hoursKey(dayKey, kind){ return `hours.${dayKey}.${kind}`; }
@@ -293,7 +308,7 @@
         row.appendChild(saveBtn);
 
         const rmBtn = document.createElement('button'); rmBtn.textContent='Remove';
-        rmBtn.onclick = async ()=>{ try{ await apiUpsert(k, ''); alert('Removed'); await loadAll(); }catch(e){ showError(e.message||'Remove failed'); } };
+        rmBtn.onclick = async ()=>{ try{ await apiDelete(k); alert('Removed'); await loadAll(); }catch(e){ showError(e.message||'Remove failed'); } };
         row.appendChild(rmBtn);
 
         list.appendChild(row);
@@ -467,7 +482,7 @@
               `syrup-on.${prevCat}.${prevKey}`,
               `coffee-on.${prevCat}.${prevKey}`,
             ];
-            for (const p of paths) await apiUpsert(p, '');
+            for (const p of paths) await apiDelete(p);
           }
 
           // Standard fields
@@ -519,16 +534,16 @@
         try {
           for (const cat of ['coffee','not-coffee','pif','specials']) {
             for (const suf of suffixes) {
-              await apiUpsert(`menu.${cat}.${suf}`, '');
-              await apiUpsert(`price.${cat}.${suf}`, '');
-              await apiUpsert(`desc.${cat}.${suf}`, '');
-              await apiUpsert(`image.${cat}.${suf}`, '');
-              await apiUpsert(`image.${cat}.${suf}.name`, '');
-              await apiUpsert(`alt.${cat}.${suf}`, '');
-              await apiUpsert(`extra.${cat}.${suf}`, '');
-              await apiUpsert(`syrups-on.${cat}.${suf}`, '');
-              await apiUpsert(`syrup-on.${cat}.${suf}`, '');
-              await apiUpsert(`coffee-on.${cat}.${suf}`, '');
+              await apiDelete(`menu.${cat}.${suf}`);
+              await apiDelete(`price.${cat}.${suf}`);
+              await apiDelete(`desc.${cat}.${suf}`);
+              await apiDelete(`image.${cat}.${suf}`);
+              await apiDelete(`image.${cat}.${suf}.name`);
+              await apiDelete(`alt.${cat}.${suf}`);
+              await apiDelete(`extra.${cat}.${suf}`);
+              await apiDelete(`syrups-on.${cat}.${suf}`);
+              await apiDelete(`syrup-on.${cat}.${suf}`);
+              await apiDelete(`coffee-on.${cat}.${suf}`);
             }
           }
           tr.parentElement.removeChild(tr);
@@ -604,7 +619,7 @@
         row.appendChild(saveBtn);
 
         const rmBtn = document.createElement('button'); rmBtn.textContent = 'Remove';
-        rmBtn.onclick = async () => { try { await apiUpsert(k, ''); alert('Removed'); await loadAll(); } catch(e){ showError(e.message || 'Remove failed'); } };
+        rmBtn.onclick = async () => { try { await apiDelete(k); alert('Removed'); await loadAll(); } catch(e){ showError(e.message || 'Remove failed'); } };
         row.appendChild(rmBtn);
 
         box.appendChild(row);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,74 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const DB_FILE = path.join(__dirname, 'store.json');
+
+function readStore() {
+  try {
+    return JSON.parse(fs.readFileSync(DB_FILE, 'utf8'));
+  } catch (e) {
+    return {};
+  }
+}
+
+function writeStore(data) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(data, null, 2));
+}
+
+function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 200;
+    return res.end();
+  }
+
+  if (req.method === 'GET' && url.pathname === '/cms-get') {
+    res.setHeader('Content-Type', 'application/json');
+    return res.end(JSON.stringify(readStore()));
+  }
+
+  if (req.method === 'POST' && url.pathname === '/cms-set') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { key, value } = JSON.parse(body || '{}');
+        if (!key) { res.statusCode = 400; return res.end(JSON.stringify({ error: 'key required' })); }
+        const store = readStore();
+        store[key] = value;
+        writeStore(store);
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'invalid json' }));
+      }
+    });
+    return;
+  }
+
+  if (req.method === 'DELETE' && url.pathname === '/cms-del') {
+    const key = url.searchParams.get('key');
+    const store = readStore();
+    delete store[key];
+    writeStore(store);
+    res.setHeader('Content-Type', 'application/json');
+    return res.end(JSON.stringify({ ok: true }));
+  }
+
+  res.statusCode = 404;
+  res.end('Not found');
+}
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  http.createServer(handleRequest).listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+} else {
+  module.exports = { handleRequest };
+}


### PR DESCRIPTION
## Summary
- add `apiDelete` helper to remove keys via DELETE request
- switch menu and key/value removal handlers to `apiDelete`
- add simple backend route to drop keys from store

## Testing
- `curl -s http://localhost:3000/cms-get; echo`
- `curl -s -X DELETE 'http://localhost:3000/cms-del?key=foo'; echo`
- `curl -s http://localhost:3000/cms-get; echo`


------
https://chatgpt.com/codex/tasks/task_e_68b5434ca31883228e10983c26989861