### PR TITLE
Add Access-Control-Allow-Methods for CORS preflight

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,6 +23,11 @@ function handleRequest(req, res) {
 
   if (req.method === 'OPTIONS') {
     res.statusCode = 200;
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
+    const requestedMethod = req.headers['access-control-request-method'];
+    if (requestedMethod) {
+      res.setHeader('Access-Control-Allow-Methods', requestedMethod);
+    }
     return res.end();
   }
 


### PR DESCRIPTION
## Summary
- ensure OPTIONS preflight responses return Access-Control-Allow-Methods
- mirror Access-Control-Request-Method when provided

## Testing
- `curl -i -X OPTIONS http://localhost:3000/cms-get -H "Access-Control-Request-Method: GET" -H "Origin: http://example.com"`

------
https://chatgpt.com/codex/tasks/task_e_68b5559e9cb48322b95f1e26c54fb858