### PR TITLE
Allow DELETE through CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,10 +20,10 @@ function handleRequest(req, res) {
   const url = new URL(req.url, `http://${req.headers.host}`);
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
 
   if (req.method === 'OPTIONS') {
     res.statusCode = 200;
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
     const requestedMethod = req.headers['access-control-request-method'];
     if (requestedMethod) {
       res.setHeader('Access-Control-Allow-Methods', requestedMethod);


### PR DESCRIPTION
## Summary
- Apply `Access-Control-Allow-Methods: GET, POST, DELETE` to all responses
- Ensure preflight requests echo the requested method when provided

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -i -X OPTIONS -H "Origin: https://example.com" -H "Access-Control-Request-Method: DELETE" http://localhost:3000/cms-del?key=test`
- `curl -i -X DELETE -H "Origin: https://example.com" "http://localhost:3000/cms-del?key=test"`


------
https://chatgpt.com/codex/tasks/task_e_68b557ef8e8c832295436da508bb3f07