### PR TITLE
Validate key in DELETE cms-del

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,10 +58,20 @@ function handleRequest(req, res) {
 
   if (req.method === 'DELETE' && url.pathname === '/cms-del') {
     const key = url.searchParams.get('key');
+    res.setHeader('Content-Type', 'application/json');
+    if (!key) {
+      res.statusCode = 400;
+      console.warn('DELETE /cms-del missing key');
+      return res.end(JSON.stringify({ error: 'key required' }));
+    }
     const store = readStore();
+    if (!Object.prototype.hasOwnProperty.call(store, key)) {
+      res.statusCode = 400;
+      console.warn('DELETE /cms-del unknown key', key);
+      return res.end(JSON.stringify({ error: 'key required' }));
+    }
     delete store[key];
     writeStore(store);
-    res.setHeader('Content-Type', 'application/json');
     return res.end(JSON.stringify({ ok: true }));
   }
 

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,37 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const { handleRequest } = require('./server');
+const DB_FILE = path.join(__dirname, 'store.json');
+
+function startServer() {
+  const server = http.createServer(handleRequest);
+  return new Promise(resolve => server.listen(0, () => resolve(server)));
+}
+
+test('DELETE /cms-del requires key parameter', async (t) => {
+  fs.rmSync(DB_FILE, { force: true });
+  const server = await startServer();
+  t.after(() => { server.close(); fs.rmSync(DB_FILE, { force: true }); });
+  const port = server.address().port;
+
+  const res = await fetch(`http://localhost:${port}/cms-del`, { method: 'DELETE' });
+  const body = await res.json();
+  assert.strictEqual(res.status, 400);
+  assert.deepStrictEqual(body, { error: 'key required' });
+});
+
+test('DELETE /cms-del rejects unknown key', async (t) => {
+  fs.rmSync(DB_FILE, { force: true });
+  const server = await startServer();
+  t.after(() => { server.close(); fs.rmSync(DB_FILE, { force: true }); });
+  const port = server.address().port;
+
+  const res = await fetch(`http://localhost:${port}/cms-del?key=missing`, { method: 'DELETE' });
+  const body = await res.json();
+  assert.strictEqual(res.status, 400);
+  assert.deepStrictEqual(body, { error: 'key required' });
+});


### PR DESCRIPTION
## Summary
- ensure DELETE /cms-del requires a valid key before deleting
- add tests verifying missing or unknown keys are rejected

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b557f6872883228644ce89555196af