### PR TITLE
Handle missing CMS keys on delete as success

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,9 +66,8 @@ function handleRequest(req, res) {
     }
     const store = readStore();
     if (!Object.prototype.hasOwnProperty.call(store, key)) {
-      res.statusCode = 400;
       console.warn('DELETE /cms-del unknown key', key);
-      return res.end(JSON.stringify({ error: 'key required' }));
+      return res.end(JSON.stringify({ ok: true }));
     }
     delete store[key];
     writeStore(store);

--- a/server.test.js
+++ b/server.test.js
@@ -24,7 +24,7 @@ test('DELETE /cms-del requires key parameter', async (t) => {
   assert.deepStrictEqual(body, { error: 'key required' });
 });
 
-test('DELETE /cms-del rejects unknown key', async (t) => {
+test('DELETE /cms-del succeeds for unknown key', async (t) => {
   fs.rmSync(DB_FILE, { force: true });
   const server = await startServer();
   t.after(() => { server.close(); fs.rmSync(DB_FILE, { force: true }); });
@@ -32,6 +32,6 @@ test('DELETE /cms-del rejects unknown key', async (t) => {
 
   const res = await fetch(`http://localhost:${port}/cms-del?key=missing`, { method: 'DELETE' });
   const body = await res.json();
-  assert.strictEqual(res.status, 400);
-  assert.deepStrictEqual(body, { error: 'key required' });
+  assert.strictEqual(res.status, 200);
+  assert.deepStrictEqual(body, { ok: true });
 });


### PR DESCRIPTION
## Summary
- Treat DELETE /cms-del for unknown keys as a no-op success
- Adjust tests to expect 200 OK when deleting missing keys

## Testing
- `node --test server.test.js`
- Simulated menu-row removal (multiple DELETE requests)

------
https://chatgpt.com/codex/tasks/task_e_68b55c8a7ff483228c00d5318245e39b