### PR TITLE
Guard deletes when optional fields are blank

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,11 @@
         }
       });
       const out = await res.json().catch(()=>({}));
-      if(!res.ok) throw new Error(out.error || `Delete failed (${res.status})`);
+      // If the key does not exist the backend may respond with 400/404.
+      // Treat those as success so that optional blank fields do not
+      // abort the save operation.
+      if(!res.ok && res.status !== 400 && res.status !== 404)
+        throw new Error(out.error || `Delete failed (${res.status})`);
       return out; // success handled by caller
     }
 

--- a/remove-handler.test.js
+++ b/remove-handler.test.js
@@ -21,7 +21,8 @@ test('remove handler deletes keys and clears row with missing data', async () =>
     if (existingKeys.has(key)) {
       return { ok: true, json: async () => ({ ok: true }) };
     }
-    return { ok: false, json: async () => ({ error: 'key required' }) };
+    // Simulate backend returning 404 for unknown keys
+    return { ok: false, status: 404, json: async () => ({ error: 'not found' }) };
   };
 
   let loadAllCalled = false;


### PR DESCRIPTION
## Summary
- Ignore 400/404 responses when deleting CMS keys so missing optional fields don't abort saves
- Simulate 404s in remove-handler test to verify deletes still proceed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55e36ebcc8322b47eeac9bb7d90fc