### PR TITLE
Handle bad request errors in apiDelete

### DIFF
--- a/api-delete.test.js
+++ b/api-delete.test.js
@@ -1,0 +1,35 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+async function setup() {
+  const html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
+  const { window } = dom;
+  await new Promise((resolve) => {
+    if (window.document.readyState === 'complete') resolve();
+    else window.document.addEventListener('DOMContentLoaded', resolve);
+  });
+  window.localStorage.setItem('cmsAnon', 'test');
+  window.showError = () => {};
+  return window;
+}
+
+test('apiDelete requires key before issuing request', async () => {
+  const window = await setup();
+  window.fetch = async () => { throw new Error('fetch should not be called'); };
+  await assert.rejects(window.apiDelete(''), /key required/);
+});
+
+test('apiDelete propagates 400 errors', async () => {
+  const window = await setup();
+  let called = false;
+  window.fetch = async () => {
+    called = true;
+    return { ok: false, status: 400, json: async () => ({ error: 'bad request' }) };
+  };
+  await assert.rejects(window.apiDelete('bad.key'), /bad request/);
+  assert.ok(called);
+});

--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
       showError('');
       const anon = getAnon();
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
+      if(!key) throw new Error('key required');
       const res = await fetch(`${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`, {
         method:'DELETE',
         headers:{
@@ -242,10 +243,10 @@
         }
       });
       const out = await res.json().catch(()=>({}));
-      // If the key does not exist the backend may respond with 400/404.
-      // Treat those as success so that optional blank fields do not
+      // If the key does not exist the backend may respond with 404.
+      // Treat that as success so that optional blank fields do not
       // abort the save operation.
-      if(!res.ok && res.status !== 400 && res.status !== 404)
+      if(!res.ok && res.status !== 404)
         throw new Error(out.error || `Delete failed (${res.status})`);
       return out; // success handled by caller
     }


### PR DESCRIPTION
## Summary
- Reject empty keys before calling the cms-del endpoint
- Only ignore 404 responses from deletes and surface 400 errors
- Cover apiDelete key checks and 400 failures with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5605d5a60832280900e2b0440e566