### PR TITLE
Handle invalid JSON responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,13 @@
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
       const res = await fetch(`${getFnsUrl()}/cms-get`, { headers:{ 'Authorization': `Bearer ${anon}` }});
       if(!res.ok) throw new Error(`GET failed: ${res.status}`);
-      return res.json();
+      const ct = res.headers.get('content-type') || '';
+      try{
+        if(!ct.includes('application/json')) throw new Error();
+        return await res.json();
+      }catch(err){
+        throw new Error('Unexpected response format');
+      }
     }
     async function apiUpsert(key, value){
       showError('');

--- a/index.html.bak
+++ b/index.html.bak
@@ -170,7 +170,13 @@
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
       const res = await fetch(`${getFnsUrl()}/cms-get`, { headers:{ 'Authorization': `Bearer ${anon}` }});
       if(!res.ok) throw new Error(`GET failed: ${res.status}`);
-      return res.json();
+      const ct = res.headers.get('content-type') || '';
+      try{
+        if(!ct.includes('application/json')) throw new Error();
+        return await res.json();
+      }catch(err){
+        throw new Error('Unexpected response format');
+      }
     }
     async function apiUpsert(key, value){
       showError('');


### PR DESCRIPTION
## Summary
- Improve `apiGetAll` to check `Content-Type` and catch JSON parsing errors.
- Mirror the updated error handling in backup file.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b56353c8808322bb3c476ab73879ef