### PR TITLE
Ensure status messages persist on refresh failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,11 +334,16 @@
           try {
             await apiDelete(k);
             row.remove();
-            await loadAll();
             showStatus('Removed');
           } catch (e) {
             showError(e.message || 'Remove failed');
             rmBtn.disabled = false; rmBtn.textContent = prevText;
+            return;
+          }
+          try {
+            await loadAll();
+          } catch (e) {
+            showError(e.message || 'Refresh failed');
           }
         };
         row.appendChild(rmBtn);
@@ -541,12 +546,16 @@
           }
           if (cCoffee.cb.checked) await apiUpsert(`coffee-on.${categoryVal}.${suffixFull}`, '1'); else await apiDelete(`coffee-on.${categoryVal}.${suffixFull}`);
 
-          showStatus('Menu entry saved.');
+          showStatus('Saved');
           data.category = categoryVal;
           data.suffix = suffix;
           data.type = typeVal;
+        } catch (e) { showError(e.message || 'Save failed'); return; }
+        try {
           await loadAll();
-        } catch (e) { showError(e.message || 'Save failed'); }
+        } catch (e) {
+          showError(e.message || 'Refresh failed');
+        }
       };
       saveTd.appendChild(saveBtn);
       tr.appendChild(saveTd);
@@ -599,11 +608,16 @@
             }
           }
           tr.parentElement.removeChild(tr);
-          await loadAll();
           showStatus('Removed');
         } catch (e) {
           showError(e.message || 'Remove failed');
           removeBtn.disabled = false; removeBtn.textContent = prevText;
+          return;
+        }
+        try {
+          await loadAll();
+        } catch (e) {
+          showError(e.message || 'Refresh failed');
         }
       };
       removeTd.appendChild(removeBtn);
@@ -681,11 +695,16 @@
           try {
             await apiDelete(k);
             row.remove();
-            await loadAll();
             showStatus('Removed');
           } catch(e){
             showError(e.message || 'Remove failed');
             rmBtn.disabled = false; rmBtn.textContent = prevText;
+            return;
+          }
+          try {
+            await loadAll();
+          } catch (e) {
+            showError(e.message || 'Refresh failed');
           }
         };
         row.appendChild(rmBtn);
@@ -706,8 +725,13 @@
             await apiUpsert(`coffee.${suf}`, lab);
             document.getElementById('coffeeSuffix').value='';
             document.getElementById('coffeeLabel').value='';
+            showStatus('Saved');
+          } catch(e){ showError(e.message || 'Save failed'); return; }
+          try {
             await loadAll();
-          } catch(e){ showError(e.message || 'Save failed'); }
+          } catch (e) {
+            showError(e.message || 'Refresh failed');
+          }
         });
         coffeeForm.dataset.bound = '1';
       }
@@ -723,8 +747,13 @@
             await apiUpsert(`syrups.${suf}`, lab);
             document.getElementById('syrupSuffix').value='';
             document.getElementById('syrupLabel').value='';
+            showStatus('Saved');
+          } catch(e){ showError(e.message || 'Save failed'); return; }
+          try {
             await loadAll();
-          } catch(e){ showError(e.message || 'Save failed'); }
+          } catch (e) {
+            showError(e.message || 'Refresh failed');
+          }
         });
         syrupForm.dataset.bound = '1';
       }
@@ -803,8 +832,13 @@
         await apiUpsert(key, val);
         document.getElementById('newKey').value='';
         document.getElementById('newVal').value='';
+        showStatus('Saved');
+      }catch(e){ showError(e.message||'Save failed'); return; }
+      try {
         await loadAll();
-      }catch(e){ showError(e.message||'Save failed'); }
+      } catch (e) {
+        showError(e.message || 'Refresh failed');
+      }
     });
 
     if(localStorage.getItem('ruminateAuth')==='true'){ loadAll(); }


### PR DESCRIPTION
## Summary
- Show "Saved" or "Removed" before reloading data in all handlers
- Isolate `loadAll()` calls so refresh errors don't override success status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5634adb4083229665589e9bb78fe0