### PR TITLE
Log apiGetAll error status and show status code in alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -789,9 +789,11 @@
         renderList(data);
         renderMenu(data);
         renderCoffeeAndSyrups(data);
-      }catch(e){
-        console.error(e);
-        const msg = e?.message ? `Load failed: ${e.message}` : 'Load failed';
+      }catch(err){
+        if(err?.status || err?.body) console.error(err.status, err.body);
+        else console.error(err);
+        const statusPart = err?.status ? ` (status ${err.status})` : '';
+        const msg = err?.message ? `Load failed${statusPart}: ${err.message}` : `Load failed${statusPart}`;
         showError(msg);
       }
     }


### PR DESCRIPTION
## Summary
- Log `apiGetAll` failures by printing status code and response body
- Include returned status code in load failure alerts for clearer feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b56ebd2b308322838bff2ce0289f99