### PR TITLE
Trim trailing slash before cms-del requests

### DIFF
--- a/api-delete.test.js
+++ b/api-delete.test.js
@@ -33,3 +33,15 @@ test('apiDelete propagates 400 errors', async () => {
   await assert.rejects(window.apiDelete('bad.key'), /bad request/);
   assert.ok(called);
 });
+
+test('apiDelete removes trailing slash from key', async () => {
+  const window = await setup();
+  let url;
+  window.fetch = async (input) => {
+    url = input;
+    return { ok: true, status: 200, json: async () => ({ ok: true }) };
+  };
+  await window.apiDelete('foo/');
+  const sentKey = new URL(url).searchParams.get('key');
+  assert.equal(sentKey, 'foo');
+});

--- a/index.html
+++ b/index.html
@@ -256,6 +256,7 @@
       const anon = getAnon();
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
       if(!key) throw new Error('key required');
+      key = key.replace(/\/$/, '');
       const res = await fetch(`${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`, {
         method:'DELETE',
         headers:{


### PR DESCRIPTION
## Summary
- sanitize delete key by removing any trailing slash before calling `cms-del`
- test delete helper to ensure the trailing slash is trimmed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b56ec43e288322a0fca714c0030e33