### PR TITLE
Allow CORS preflight for DELETE requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,15 +19,11 @@ function writeStore(data) {
 function handleRequest(req, res) {
   const url = new URL(req.url, `http://${req.headers.host}`);
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Headers', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-cms-secret');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
 
   if (req.method === 'OPTIONS') {
     res.statusCode = 200;
-    const requestedMethod = req.headers['access-control-request-method'];
-    if (requestedMethod) {
-      res.setHeader('Access-Control-Allow-Methods', requestedMethod);
-    }
     return res.end();
   }
 


### PR DESCRIPTION
## Summary
- permit Authorization and x-cms-secret headers and advertise OPTIONS in allowed methods
- answer preflight OPTIONS with HTTP 200 and CORS headers

## Testing
- `npm test`
- `npx --yes supabase functions deploy cms` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b57230f67c83229fc1a9f597ab7fb8