### PR TITLE
Improve apiDelete network error handling

### DIFF
--- a/api-delete.test.js
+++ b/api-delete.test.js
@@ -45,3 +45,12 @@ test('apiDelete removes trailing slash from key', async () => {
   const sentKey = new URL(url).searchParams.get('key');
   assert.equal(sentKey, 'foo');
 });
+
+test('apiDelete throws descriptive error on network failure', async () => {
+  const window = await setup();
+  window.fetch = async () => { throw new TypeError('Failed to fetch'); };
+  await assert.rejects(
+    window.apiDelete('foo'),
+    /Network or CORS error while deleting key/
+  );
+});

--- a/index.html
+++ b/index.html
@@ -257,13 +257,18 @@
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
       if(!key) throw new Error('key required');
       key = key.replace(/\/$/, '');
-      const res = await fetch(`${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`, {
-        method:'DELETE',
-        headers:{
-          'Authorization': `Bearer ${anon}`,
-          'x-cms-secret': WRITE_SECRET
-        }
-      });
+      let res;
+      try {
+        res = await fetch(`${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`, {
+          method:'DELETE',
+          headers:{
+            'Authorization': `Bearer ${anon}`,
+            'x-cms-secret': WRITE_SECRET
+          }
+        });
+      } catch (err) {
+        throw new Error('Network or CORS error while deleting key.');
+      }
       const out = await res.json().catch(()=>({}));
       // If the key does not exist the backend may respond with 404.
       // Treat that as success so that optional blank fields do not


### PR DESCRIPTION
## Summary
- Wrap `apiDelete` fetch in a try/catch and throw a clearer error for network/CORS failures
- Test network error handling in `apiDelete`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57237d30883228abd7fd3be94a53a