### PR TITLE
Allow apikey and client headers in CORS preflight

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,10 @@ function writeStore(data) {
 function handleRequest(req, res) {
   const url = new URL(req.url, `http://${req.headers.host}`);
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-cms-secret');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization, x-cms-secret, apikey, x-client-info'
+  );
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
 
   if (req.method === 'OPTIONS') {

--- a/server.test.js
+++ b/server.test.js
@@ -91,3 +91,22 @@ test('DELETE /cms-del succeeds for unknown key', async (t) => {
   assert.strictEqual(res.status, 200);
   assert.deepStrictEqual(body, { ok: true });
 });
+
+test('OPTIONS allows apikey and x-client-info headers', async (t) => {
+  fs.rmSync(DB_FILE, { force: true });
+  const server = await startServer();
+  t.after(() => { server.close(); fs.rmSync(DB_FILE, { force: true }); });
+  const port = server.address().port;
+
+  const res = await fetch(`http://localhost:${port}/cms-set`, {
+    method: 'OPTIONS',
+    headers: {
+      'Access-Control-Request-Headers': 'apikey, x-client-info'
+    }
+  });
+
+  assert.strictEqual(res.status, 200);
+  const allow = res.headers.get('access-control-allow-headers');
+  assert.ok(allow.includes('apikey'));
+  assert.ok(allow.includes('x-client-info'));
+});


### PR DESCRIPTION
## Summary
- permit apikey and x-client-info headers in CORS responses
- test OPTIONS preflight for these headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5754d33ac83228283b8ba7f118cb6