### PR TITLE
Trim key before removing trailing slash in apiDelete

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
       const anon = getAnon();
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
       if(!key) throw new Error('key required');
-      key = key.replace(/\/$/, '');
+      key = key.trim().replace(/\/$/, '');
       let res;
       try {
         res = await fetch(`${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`, {


### PR DESCRIPTION
## Summary
- Trim key before removing trailing slash in apiDelete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57f1bbea0832287210c3b78cf912a