### PR TITLE
Short-circuit apiDelete when key missing

### DIFF
--- a/api-delete.test.js
+++ b/api-delete.test.js
@@ -17,10 +17,13 @@ async function setup() {
   return window;
 }
 
-test('apiDelete requires key before issuing request', async () => {
+test('apiDelete returns early when key is missing', async () => {
   const window = await setup();
-  window.fetch = async () => { throw new Error('fetch should not be called'); };
-  await assert.rejects(window.apiDelete(''), /key required/);
+  let called = false;
+  window.fetch = async () => { called = true; };
+  const out = await window.apiDelete('');
+  assert.equal(out, undefined);
+  assert.equal(called, false);
 });
 
 test('apiDelete propagates 400 errors', async () => {

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
       showError('');
       const anon = getAnon();
       if(!anon) throw new Error('Supabase Anon key not set (click “Set Supabase anon key”).');
-      if(!key) throw new Error('key required');
+      if(!key) return; // short-circuit
       key = key.trim().replace(/\/$/, '');
       let res;
       try {


### PR DESCRIPTION
## Summary
- Avoid API deletion errors by returning early when key is missing
- Update apiDelete tests for new short-circuit behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b592f8957c8322a98398b9f3a0fc78