### PR TITLE
Echo origin in CMS delete CORS

### DIFF
--- a/supabase/functions/cms-del/index.ts
+++ b/supabase/functions/cms-del/index.ts
@@ -1,16 +1,21 @@
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, apikey, x-cms-secret, content-type, x-client-info',
-  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-};
+function corsHeaders(origin: string | null) {
+  return {
+    'Access-Control-Allow-Origin': origin ?? '',
+    'Access-Control-Allow-Headers':
+      'authorization, apikey, x-cms-secret, content-type, x-client-info',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  };
+}
 
 Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
+    return new Response('ok', { headers: corsHeaders(origin) });
   }
 
   if (req.method !== 'DELETE') {
-    return new Response('Not found', { status: 404, headers: corsHeaders });
+    return new Response('Not found', { status: 404, headers: corsHeaders(origin) });
   }
 
   const url = new URL(req.url);
@@ -18,12 +23,13 @@ Deno.serve(async (req) => {
   if (!key) {
     return new Response(JSON.stringify({ error: 'key required' }), {
       status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      headers: { ...corsHeaders(origin), 'Content-Type': 'application/json' },
     });
   }
   // In a real implementation you would remove the key from your store here.
   // This demo simply acknowledges the request.
-  return new Response(JSON.stringify({ ok: true }), {
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(origin),
   });
 });


### PR DESCRIPTION
## Summary
- return requesting origin in CORS headers for CMS delete function
- respond with 204 No Content after deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a3d46adc832298401fadfa9c8839