### PR TITLE
Handle optional checkout URLs in config

### DIFF
--- a/config-checkout.test.js
+++ b/config-checkout.test.js
@@ -1,0 +1,34 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+async function loadDomWithConfig(config) {
+  const html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) {
+      if (config !== undefined) {
+        window.CONFIG = config;
+      }
+    },
+  });
+  await new Promise(resolve => {
+    if (dom.window.document.readyState === 'complete') resolve();
+    else dom.window.document.addEventListener('DOMContentLoaded', resolve);
+  });
+  return dom.window;
+}
+
+test('checkout defaults to empty strings when CONFIG missing', async () => {
+  const window = await loadDomWithConfig(undefined);
+  assert.deepStrictEqual({ ...window.checkout }, { pos: '', portal: '', app: '' });
+});
+
+test('checkout reads urls from CONFIG when provided', async () => {
+  const window = await loadDomWithConfig({ checkoutUrls: { pos: 'p', portal: 'o', app: 'a' } });
+  assert.deepStrictEqual({ ...window.checkout }, { pos: 'p', portal: 'o', app: 'a' });
+});

--- a/index.html
+++ b/index.html
@@ -173,6 +173,12 @@
     const WRITE_SECRET = "Misterbignose12!";
     const VIEW_PASSWORD = "Misterbignose12!";
 
+    // Safe access to optional configuration and checkout URLs
+    const cfg = (window.CONFIG ?? {});
+    const checkout = (cfg.checkoutUrls ?? {});
+    const { pos, portal, app } = (cfg.checkoutUrls ?? { pos: '', portal: '', app: '' });
+    window.checkout = { pos, portal, app };
+
     function getFnsUrl(){ return localStorage.getItem('cmsFunctionsUrl') || DEFAULT_FUNCTIONS_URL; }
     function setFnsUrl(u){ if(u) localStorage.setItem('cmsFunctionsUrl', u); }
     function getAnon(){ return localStorage.getItem('cmsAnon') || ''; }


### PR DESCRIPTION
## Summary
- Safely access global CONFIG and checkout URLs with defaults
- Expose checkout URLs on `window.checkout` for consumers
- Add tests to ensure checkout URLs handle missing or provided config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a3cb25948322896517fa9cda2841