### PR TITLE
Fix CMS config defaults and robust delete handling

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,11 +1,11 @@
     // ---- Config (can override via localStorage) ----
-    const DEFAULT_FUNCTIONS_URL = "https://eamewialuovzguldcdcf.functions.supabase.co";
+    const DEFAULT_FUNCTIONS_URL = globalThis.DEFAULT_FUNCTIONS_URL || 'https://eamewialuovzguldcdcf.functions.supabase.co';
     const WRITE_SECRET = "Misterbignose12!";
     const VIEW_PASSWORD = "Misterbignose12!";
 
     // Safe CONFIG defaults
     const config = (globalThis.CONFIG ?? {});
-    const { pos, portal, app } = (config?.checkoutUrls ?? { pos: '', portal: '', app: '' });
+    const { pos, portal, app } = (config.checkoutUrls ?? { pos: '', portal: '', app: '' });
     globalThis.checkout = { pos, portal, app };
 
     function getFnsUrl(){ return localStorage.getItem('cmsFunctionsUrl') || DEFAULT_FUNCTIONS_URL; }
@@ -102,9 +102,9 @@
       const url = `${getFnsUrl()}/cms-del?key=${encodeURIComponent(key)}`;
       try {
         res = await fetch(url, {
-          method:'DELETE',
-          headers:{
-            'Content-Type':'application/json',
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
             'apikey': anon,
             'Authorization': `Bearer ${anon}`,
             'x-client-info': 'cms-ui'
@@ -113,10 +113,10 @@
       } catch (err) {
         throw new Error('Network or CORS error while deleting key.');
       }
-      if(!(res.ok || res.status === 204)){
-        const text = await res.text().catch(()=> '');
+      if (!(res.ok || res.status === 204)) {
+        const text = await res.text().catch(() => '');
         showError(text);
-        throw new Error(text || `cms-del failed ${res.status}`);
+        throw new Error(`cms-del failed ${res.status}: ${text}`);
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,12 @@
     th, td { border-bottom: 1px dashed var(--line); padding: 6px; vertical-align: middle; }
     th { text-align: left; }
   </style>
+  <script>
+    // Hard defaults so the bundle can read safely
+    window.DEFAULT_FUNCTIONS_URL ??= 'https://eamewialuovzguldcdcf.functions.supabase.co';
+    window.CONFIG = window.CONFIG || {};
+    window.CONFIG.checkoutUrls = window.CONFIG.checkoutUrls || { pos: '', portal: '', app: '' };
+  </script>
   <script src="shim.js"></script>
   <script src="content.js?v=__BUILD_HASH__" defer></script>
 </head>


### PR DESCRIPTION
## Summary
- Stub global CONFIG and DEFAULT_FUNCTIONS_URL before bundle loads
- Guard config reads and tighten delete request handling

## Testing
- `npm test`
- `supabase functions deploy cms-del` *(fails: command not found)*
- `curl -i -X OPTIONS https://eamewialuovzguldcdcf.functions.supabase.co/cms-del?key=x -H 'Origin: https://q06mrashid-sketch.github.io' -H 'Access-Control-Request-Method: DELETE' -H 'Access-Control-Request-Headers: authorization, apikey, content-type'` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac0d40b08322a8f7b09f54cf61f0