### PR TITLE
Handle CORS preflight for Supabase CMS functions

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,13 +1,13 @@
-export const ALLOWED_ORIGINS = new Set<string>([
+export const ALLOW = new Set([
   'https://q06mrashid-sketch.github.io',
   'http://localhost:5173',
   'http://localhost:3000',
 ]);
 
 export function corsHeaders(origin?: string) {
-  const allowOrigin = origin && ALLOWED_ORIGINS.has(origin) ? origin : 'https://q06mrashid-sketch.github.io';
+  const allow = origin && ALLOW.has(origin) ? origin : 'https://q06mrashid-sketch.github.io';
   return {
-    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Origin': allow,
     'Vary': 'Origin',
     'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -15,7 +15,7 @@ export function corsHeaders(origin?: string) {
   } as const;
 }
 
-export function handleOptions(req: Request) {
+export function preflight(req: Request) {
   if (req.method === 'OPTIONS') {
     const origin = req.headers.get('Origin') ?? undefined;
     return new Response('ok', { status: 200, headers: corsHeaders(origin) });

--- a/supabase/functions/cms-del/index.ts
+++ b/supabase/functions/cms-del/index.ts
@@ -1,10 +1,10 @@
-
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
-import { handleOptions, json, corsHeaders } from '../_shared/cors.ts';
+import { preflight, corsHeaders, json } from '../_shared/cors.ts';
 
 serve(async (req) => {
-  const opt = handleOptions(req);
-  if (opt) return opt;
+  // 0) OPTIONS preflight (must be first)
+  const pf = preflight(req);
+  if (pf) return pf;
 
   const origin = req.headers.get('Origin') ?? undefined;
 
@@ -13,19 +13,23 @@ serve(async (req) => {
       return json({ error: 'Method not allowed' }, { status: 405 }, origin);
     }
 
-    const url = new URL(req.url);
-    const key = url.searchParams.get('key');
-    if (!key) return json({ error: 'Missing key' }, { status: 400 }, origin);
-
+    // Auth AFTER preflight
     const auth = req.headers.get('Authorization') ?? '';
     const apiKey = req.headers.get('apikey') ?? '';
     if (!auth.startsWith('Bearer ') || !apiKey) {
       return json({ error: 'Unauthorized' }, { status: 401 }, origin);
     }
 
+    const url = new URL(req.url);
+    const key = url.searchParams.get('key');
+    if (!key) return json({ error: 'Missing key' }, { status: 400 }, origin);
+
+    // TODO: perform the delete in your storage/db here
+
+    // 204 with CORS
     return new Response(null, { status: 204, headers: corsHeaders(origin) });
-  } catch (err) {
-    console.error('cms-del error', err);
-    return json({ error: String((err as any)?.message ?? err) }, { status: 500 }, origin);
+  } catch (e) {
+    console.error('cms-del error', e);
+    return json({ error: String((e as any)?.message ?? e) }, { status: 500 }, origin);
   }
 });

--- a/supabase/functions/cms-put/index.ts
+++ b/supabase/functions/cms-put/index.ts
@@ -1,9 +1,10 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
-import { handleOptions, json } from '../_shared/cors.ts';
+import { preflight, json } from '../_shared/cors.ts';
 
 serve(async (req) => {
-  const opt = handleOptions(req);
-  if (opt) return opt;
+  // 0) OPTIONS preflight (must be first)
+  const pf = preflight(req);
+  if (pf) return pf;
 
   const origin = req.headers.get('Origin') ?? undefined;
 
@@ -16,6 +17,7 @@ serve(async (req) => {
     const key = url.searchParams.get('key');
     if (!key) return json({ error: 'Missing key' }, { status: 400 }, origin);
 
+    // Auth AFTER preflight
     const auth = req.headers.get('Authorization') ?? '';
     const apiKey = req.headers.get('apikey') ?? '';
     if (!auth.startsWith('Bearer ') || !apiKey) {
@@ -29,8 +31,8 @@ serve(async (req) => {
     }
 
     return json({ ok: true }, {}, origin);
-  } catch (err) {
-    console.error('cms-put error', err);
-    return json({ error: String((err as any)?.message ?? err) }, { status: 500 }, origin);
+  } catch (e) {
+    console.error('cms-put error', e);
+    return json({ error: String((e as any)?.message ?? e) }, { status: 500 }, origin);
   }
 });


### PR DESCRIPTION
## Summary
- centralize CORS settings in a shared helper with preflight and JSON utilities
- ensure cms-del, cms-get and cms-put respond 200 to OPTIONS before auth

## Testing
- `npm test`
- `supabase functions deploy cms-del` *(fails: command not found)*
- `supabase functions deploy cms-get` *(fails: command not found)*
- `supabase functions deploy cms-put` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b692ce328483229594436429c040bd