### PR TITLE
Inline CMS config and add cms-del edge function

### DIFF
--- a/api-delete.test.js
+++ b/api-delete.test.js
@@ -8,6 +8,7 @@ async function setup() {
   let html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
   html = html.replace(/<script[^>]*src="shim.js"[^>]*><\/script>\n?/, '')
              .replace(/<script[^>]*src="\/cms-config.js"[^>]*><\/script>\n?/, '')
+             .replace(/<script>\s*window\.RUMINATE_CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
              .replace(/<script[^>]*src="[^"']*content.js[^>]*><\/script>\n?/, '');
   const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
   const { window } = dom;
@@ -15,6 +16,7 @@ async function setup() {
     if (window.document.readyState === 'complete') resolve();
     else window.document.addEventListener('DOMContentLoaded', resolve);
   });
+  window.RUMINATE_CMS_CONFIG = { checkoutUrls: { del: 'https://example.com/cms-del' } };
   window.eval(fs.readFileSync(path.join(__dirname, 'shim.js'), 'utf8'));
   window.eval(fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8'));
   window.localStorage.setItem('cmsAnon', 'test');

--- a/config-checkout.test.js
+++ b/config-checkout.test.js
@@ -8,6 +8,7 @@ async function loadDomWithConfig(config) {
   let html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
   html = html.replace(/<script[^>]*src="shim.js"[^>]*><\/script>/, '')
              .replace(/<script[^>]*src="\/cms-config.js"[^>]*><\/script>/, '')
+             .replace(/<script>\s*window\.RUMINATE_CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
              .replace(/<script[^>]*src="[^"']*content.js[^>]*><\/script>/, '');
   const dom = new JSDOM(html, {
     runScripts: 'dangerously',

--- a/index.html
+++ b/index.html
@@ -174,7 +174,15 @@
 
   </div>
 
-  <script src="./cms-config.js"></script>
-<script src="./content.js"></script>
+    <script>
+      window.RUMINATE_CMS_CONFIG = {
+        checkoutUrls: {
+          get: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-get",
+          set: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-set",
+          del: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del"
+        }
+      };
+    </script>
+  <script src="./content.js"></script>
 </body>
 </html>

--- a/remove-handler.test.js
+++ b/remove-handler.test.js
@@ -8,6 +8,7 @@ test('remove handler deletes keys and clears row with missing data', async () =>
   let html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
   html = html.replace(/<script[^>]*src="shim.js"[^>]*><\/script>\n?/, '')
              .replace(/<script[^>]*src="\/cms-config.js"[^>]*><\/script>\n?/, '')
+             .replace(/<script>\s*window\.RUMINATE_CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
              .replace(/<script[^>]*src="[^"']*content.js[^>]*><\/script>\n?/, '');
   const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
   const { window } = dom;
@@ -15,6 +16,7 @@ test('remove handler deletes keys and clears row with missing data', async () =>
     if (window.document.readyState === 'complete') resolve();
     else window.document.addEventListener('DOMContentLoaded', resolve);
   });
+  window.RUMINATE_CMS_CONFIG = { checkoutUrls: { del: 'https://example.com/cms-del' } };
   window.eval(fs.readFileSync(path.join(__dirname, 'shim.js'), 'utf8'));
   window.eval(fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8'));
 


### PR DESCRIPTION
## Summary
- inline CMS configuration to eliminate 404s
- add cms-del edge function with service-role support
- make delete actions configurable and disable when unsupported

## Testing
- `npm test`
- `npx --yes supabase secrets set SUPABASE_SERVICE_ROLE_KEY='YOUR_SERVICE_ROLE_KEY' --project-ref eamewialuovzguldcdcf` *(fails: Access token not provided)*
- `npx --yes supabase link --project-ref eamewialuovzguldcdcf` *(fails: Access token not provided)*
- `npx --yes supabase functions deploy cms-del --no-verify-jwt --project-ref eamewialuovzguldcdcf` *(fails: Access token not provided)*
- `curl -i -X OPTIONS -H "Origin: https://q06mrashid-sketch.github.io" -H "Access-Control-Request-Method: DELETE" "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del?key=test"` *(fails: CONNECT tunnel failed 403)*
- `curl -i -X DELETE -H "Origin: https://q06mrashid-sketch.github.io" "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del?key=test"` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b9d07a3083229ab42637c150ee77