### PR TITLE
CMS: add cms-config.js and load via relative path to fix checkoutUrls undefined

### DIFF
--- a/api-delete.test.js
+++ b/api-delete.test.js
@@ -7,8 +7,8 @@ const { JSDOM } = require('jsdom');
 async function setup() {
   let html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
   html = html.replace(/<script[^>]*src="shim.js"[^>]*><\/script>\n?/, '')
-             .replace(/<script[^>]*src="\/cms-config.js"[^>]*><\/script>\n?/, '')
-             .replace(/<script>\s*window\.RUMINATE_CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
+             .replace(/<script[^>]*src="\.\/cms-config.js"[^>]*><\/script>\n?/, '')
+             .replace(/<script>\s*window\.CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
              .replace(/<script[^>]*src="[^"']*content.js[^>]*><\/script>\n?/, '');
   const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
   const { window } = dom;
@@ -16,7 +16,7 @@ async function setup() {
     if (window.document.readyState === 'complete') resolve();
     else window.document.addEventListener('DOMContentLoaded', resolve);
   });
-  window.RUMINATE_CMS_CONFIG = { checkoutUrls: { del: 'https://example.com/cms-del' } };
+  window.CMS_CONFIG = { api: { del: 'https://example.com/cms-del' } };
   window.eval(fs.readFileSync(path.join(__dirname, 'shim.js'), 'utf8'));
   window.eval(fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8'));
   window.localStorage.setItem('cmsAnon', 'test');

--- a/cms-config.js
+++ b/cms-config.js
@@ -1,9 +1,12 @@
-// cms-config.js
-window.RUMINATE_CMS_CONFIG = {
-  // whatever else your app reads…
+window.CMS_CONFIG = {
+  projectRef: "eamewialuovzguldcdcf",
   checkoutUrls: {
-    get: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-get",
-    set: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-set",
-    del: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del"
+    prod: "#",
+    dev:  "#"
+  },
+  api: {
+    del: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del",
+    get: "",
+    set: ""
   }
 };

--- a/config-checkout.test.js
+++ b/config-checkout.test.js
@@ -7,8 +7,8 @@ const { JSDOM } = require('jsdom');
 async function loadDomWithConfig(config) {
   let html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
   html = html.replace(/<script[^>]*src="shim.js"[^>]*><\/script>/, '')
-             .replace(/<script[^>]*src="\/cms-config.js"[^>]*><\/script>/, '')
-             .replace(/<script>\s*window\.RUMINATE_CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
+             .replace(/<script[^>]*src="\.\/cms-config.js"[^>]*><\/script>/, '')
+             .replace(/<script>\s*window\.CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
              .replace(/<script[^>]*src="[^"']*content.js[^>]*><\/script>/, '');
   const dom = new JSDOM(html, {
     runScripts: 'dangerously',
@@ -16,7 +16,7 @@ async function loadDomWithConfig(config) {
     url: 'http://localhost',
     beforeParse(window) {
       if (config !== undefined) {
-        window.RUMINATE_CMS_CONFIG = config;
+        window.CMS_CONFIG = config;
       }
     },
   });

--- a/content.js
+++ b/content.js
@@ -1,5 +1,5 @@
     // ---- Config (can override via localStorage) ----
-    const GLOBALS = globalThis.RUMINATE_CMS_CONFIG ?? {};
+    const GLOBALS = globalThis.CMS_CONFIG ?? {};
     const config = globalThis.CONFIG || {};
     const DEFAULT_FUNCTIONS_URL = config.DEFAULT_FUNCTIONS_URL || GLOBALS.api?.baseUrl || 'https://eamewialuovzguldcdcf.functions.supabase.co';
     const WRITE_SECRET = "Misterbignose12!";
@@ -7,7 +7,7 @@
 
     const checkoutUrls = GLOBALS.checkoutUrls ?? { web: "/checkout" };
     globalThis.checkoutUrls = checkoutUrls;
-    const canDelete = !!checkoutUrls.del;
+    const canDelete = !!GLOBALS.api?.del;
 
     function getFnsUrl(){ return localStorage.getItem('cmsFunctionsUrl') || DEFAULT_FUNCTIONS_URL; }
     function setFnsUrl(u){ if(u) localStorage.setItem('cmsFunctionsUrl', u); }
@@ -101,7 +101,7 @@
       if(!key) return; // short-circuit
       key = key.trim().replace(/\/$/, '');
       let res;
-      const url = `${checkoutUrls.del}?key=${encodeURIComponent(key)}`;
+      const url = `${GLOBALS.api.del}?key=${encodeURIComponent(key)}`;
       try {
         res = await fetch(url, {
           method: 'DELETE',

--- a/index.html
+++ b/index.html
@@ -174,15 +174,7 @@
 
   </div>
 
-    <script>
-      window.RUMINATE_CMS_CONFIG = {
-        checkoutUrls: {
-          get: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-get",
-          set: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-set",
-          del: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del"
-        }
-      };
-    </script>
+  <script src="./cms-config.js"></script>
   <script src="./content.js"></script>
 </body>
 </html>

--- a/public/cms-config.js
+++ b/public/cms-config.js
@@ -1,9 +1,12 @@
-window.RUMINATE_CMS_CONFIG = {
+window.CMS_CONFIG = {
+  projectRef: "eamewialuovzguldcdcf",
   checkoutUrls: {
-    web: "/checkout",
-    app: "ruminate://checkout"
+    prod: "#",
+    dev:  "#"
   },
   api: {
-    baseUrl: "https://eamewialuovzguldcdcf.functions.supabase.co"
+    del: "https://eamewialuovzguldcdcf.functions.supabase.co/cms-del",
+    get: "",
+    set: ""
   }
 };

--- a/remove-handler.test.js
+++ b/remove-handler.test.js
@@ -7,8 +7,8 @@ const { JSDOM } = require('jsdom');
 test('remove handler deletes keys and clears row with missing data', async () => {
   let html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
   html = html.replace(/<script[^>]*src="shim.js"[^>]*><\/script>\n?/, '')
-             .replace(/<script[^>]*src="\/cms-config.js"[^>]*><\/script>\n?/, '')
-             .replace(/<script>\s*window\.RUMINATE_CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
+             .replace(/<script[^>]*src="\.\/cms-config.js"[^>]*><\/script>\n?/, '')
+             .replace(/<script>\s*window\.CMS_CONFIG[\s\S]*?<\/script>\n?/, '')
              .replace(/<script[^>]*src="[^"']*content.js[^>]*><\/script>\n?/, '');
   const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
   const { window } = dom;
@@ -16,7 +16,7 @@ test('remove handler deletes keys and clears row with missing data', async () =>
     if (window.document.readyState === 'complete') resolve();
     else window.document.addEventListener('DOMContentLoaded', resolve);
   });
-  window.RUMINATE_CMS_CONFIG = { checkoutUrls: { del: 'https://example.com/cms-del' } };
+  window.CMS_CONFIG = { api: { del: 'https://example.com/cms-del' } };
   window.eval(fs.readFileSync(path.join(__dirname, 'shim.js'), 'utf8'));
   window.eval(fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8'));
 


### PR DESCRIPTION
## Summary
- define window.CMS_CONFIG with projectRef, checkoutUrls and API endpoints
- load cms-config.js via relative path before other scripts
- read CMS_CONFIG from content.js and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6c0ab8c44832299e8563515f2da16