### PR TITLE
Allow mobile access to CMS functions

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -22,13 +22,25 @@ function pickAllowOrigin(req: Request): string {
 
 export function corsHeaders(req?: Request) {
   const allowOrigin = req ? pickAllowOrigin(req) : (ALLOWED_LIST[0] || defaultOrigin);
+  const allowHeaders = [
+    // headers we rely on for auth + standard request metadata
+    "authorization",
+    "apikey",
+    "content-type",
+    "x-requested-with",
+    "x-client-info",
+  ];
+  // Allow (but don't require) the optional write secret header
+  const cmsSecret =
+    Deno.env.get("CMS_SECRET") ?? Deno.env.get("CMS_WRITE_SECRET");
+  if (cmsSecret) allowHeaders.push("x-cms-secret");
+
   return {
     "Access-Control-Allow-Origin": allowOrigin,
     "Vary": "Origin",
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers":
-      // IMPORTANT: include x-cms-secret + headers you already use
-      "authorization, apikey, content-type, x-requested-with, x-client-info, x-cms-secret",
+    // IMPORTANT: headers that mobile clients (RN fetch) may send
+    "Access-Control-Allow-Headers": allowHeaders.join(", "),
     "Access-Control-Max-Age": "86400",
   } as const;
 }

--- a/supabase/functions/cms-get/index.ts
+++ b/supabase/functions/cms-get/index.ts
@@ -37,6 +37,7 @@ serve(async (req) => {
         if (value !== undefined) break;
       }
     }
+    console.log("cms-get key=", key, "hit=", !!value);
     return json({ key, value: value ?? null });
   } catch (e) {
     return json({ error: String(e) }, { status: 500 });

--- a/supabase/functions/cms-list/index.ts
+++ b/supabase/functions/cms-list/index.ts
@@ -31,6 +31,7 @@ serve(async (req) => {
         break;
       }
     }
+    console.log("cms-list like=", like, "keys=", keys.length);
     return json({ count: keys.length, keys });
   } catch (e) {
     return json({ error: String(e) }, { status: 500 });


### PR DESCRIPTION
## Summary
- Dynamically build CORS allowed headers including auth, API key, content-type and optional x-cms-secret
- Add logging to cms-list and cms-get endpoints

## Testing
- `npm test`
- `npx --yes supabase@latest functions deploy cms-list cms-get` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68bf411bd9908322a83c3df3bb20c96c